### PR TITLE
Show underline on the nav link for child routes as well

### DIFF
--- a/src/app/shared/components/links/nav-link/nav-link.component.html
+++ b/src/app/shared/components/links/nav-link/nav-link.component.html
@@ -1,8 +1,7 @@
 <div
   class="nav-link no-outline border-bottom-reveal"
   [routerLink]="[link]"
-  routerLinkActive="link-active"
-  [routerLinkActiveOptions]="routerLinkActiveOptions"
+  [class.link-active]="isActive"
 >
   <ng-content></ng-content>
 </div>

--- a/src/app/shared/components/links/nav-link/nav-link.component.ts
+++ b/src/app/shared/components/links/nav-link/nav-link.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input } from "@angular/core";
+import { IsActiveMatchOptions, Router } from "@angular/router";
 
 @Component({
   selector: "app-nav-link",
@@ -9,7 +10,27 @@ export class NavLinkComponent {
   @Input()
   link: string = "";
 
-  readonly routerLinkActiveOptions = {
-    exact: true,
+  readonly routerLinkActiveOptions: IsActiveMatchOptions = {
+    paths: "subset",
+    matrixParams: "ignored",
+    queryParams: "ignored",
+    fragment: "ignored",
   };
+
+  private get exactOrSubset(): "exact" | "subset" {
+    return this.link === "" ? "exact" : "subset";
+  }
+
+  get isActive() {
+    const opts: IsActiveMatchOptions = {
+      paths: this.exactOrSubset,
+      queryParams: this.exactOrSubset,
+      fragment: "ignored",
+      matrixParams: "ignored",
+    };
+
+    return this.router.isActive(this.link, opts);
+  }
+
+  constructor(private router: Router) {}
 }


### PR DESCRIPTION
- Show underline on a nav link if the current route is same as the passed `link` input or any of it's child routes.
- handle special case for `Home` route which is the base route. If we see this route, we make the path match to be exact.
    - This is required because all the routes will be a child route of the base route `""`. So, the `Home` link will always be highlighted.

Closes #29 