### PR TITLE
add router links in blog list page, update simple card to show link & normal heading

### DIFF
--- a/src/app/blog/components/blog-entry/blog-entry.component.html
+++ b/src/app/blog/components/blog-entry/blog-entry.component.html
@@ -2,6 +2,7 @@
   <div class="date">{{ blog.creationDate | date: "mediumDate" }}</div>
   <app-simple-card
     [heading]="blog.title"
+    [headingUrl]="blog.url"
     [body]="blog.description"
     [tags]="blog.tags"
   ></app-simple-card>

--- a/src/app/shared/components/links/links.module.ts
+++ b/src/app/shared/components/links/links.module.ts
@@ -3,10 +3,15 @@ import { CommonModule } from "@angular/common";
 import { NavLinkComponent } from "./nav-link/nav-link.component";
 import { RouterModule } from "@angular/router";
 import { SimpleLinkComponent } from "./simple-link/simple-link.component";
+import { SimpleRouterLinkComponent } from "./simple-router-link/simple-router-link.component";
 
 @NgModule({
-  declarations: [NavLinkComponent, SimpleLinkComponent],
+  declarations: [
+    NavLinkComponent,
+    SimpleLinkComponent,
+    SimpleRouterLinkComponent,
+  ],
   imports: [CommonModule, RouterModule],
-  exports: [NavLinkComponent, SimpleLinkComponent],
+  exports: [NavLinkComponent, SimpleLinkComponent, SimpleRouterLinkComponent],
 })
 export class LinksModule {}

--- a/src/app/shared/components/links/simple-router-link/simple-router-link.component.ts
+++ b/src/app/shared/components/links/simple-router-link/simple-router-link.component.ts
@@ -1,0 +1,25 @@
+import { Component, ChangeDetectionStrategy, Input } from "@angular/core";
+
+@Component({
+  selector: "app-simple-router-link",
+  template: `
+    <a [routerLink]="urlFragments">
+      <ng-content></ng-content>
+    </a>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SimpleRouterLinkComponent {
+  @Input()
+  set url(_url: string | string[]) {
+    if (typeof _url === "string") {
+      this.urlFragments = [_url];
+    }
+
+    if (Array.isArray(_url)) {
+      this.urlFragments = _url;
+    }
+  }
+
+  urlFragments: string[] = [];
+}

--- a/src/app/shared/components/simple-card/simple-card.component.html
+++ b/src/app/shared/components/simple-card/simple-card.component.html
@@ -1,7 +1,13 @@
 <div class="card">
-  <app-simple-link>
-    <div class="title border-bottom-reveal">{{ heading }}</div>
-  </app-simple-link>
+  <div class="title">
+    <ng-container *ngIf="!!headingUrl; else textHeading">
+      <app-simple-router-link [url]="headingUrl">
+        <span class="border-bottom-reveal">{{
+          heading
+        }}</span></app-simple-router-link
+      >
+    </ng-container>
+  </div>
   <div class="description">{{ body }}</div>
   <div class="tags">
     <app-simple-tag
@@ -11,3 +17,7 @@
     ></app-simple-tag>
   </div>
 </div>
+
+<ng-template #textHeading>
+  <span>{{ heading }}</span>
+</ng-template>

--- a/src/app/shared/components/simple-card/simple-card.component.scss
+++ b/src/app/shared/components/simple-card/simple-card.component.scss
@@ -12,7 +12,6 @@
     font-weight: var(--font-weight-bold);
     margin-bottom: var(--spacing-s1);
     position: relative;
-    display: inline-block;
   }
 
   .description {

--- a/src/app/shared/components/simple-card/simple-card.component.ts
+++ b/src/app/shared/components/simple-card/simple-card.component.ts
@@ -10,6 +10,8 @@ export class SimpleCardComponent {
   @Input()
   heading: string;
   @Input()
+  headingUrl: string;
+  @Input()
   body: string;
   @Input()
   tags: TagBase[];

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -53,3 +53,8 @@ body {
 .centred-content-container {
   padding: var(--spacing-s3) var(--spacing-s10);
 }
+
+a {
+  text-decoration: none;
+  color: var(--color-primary);
+}


### PR DESCRIPTION
- Added a new component `SimpleRouterLinkComponent` which will create a `<a>` tag with `[routerlink]`
- Modified `SimpleCardComponent` to accept `headingUrl` and render a link / text heading based on it
- Added `headingUrl` to `BlogEntryComponent`. The cards now show heading as a link. Clicking on this link will route to the blog post.

Closes #24 